### PR TITLE
fixing path parameters in configuration file

### DIFF
--- a/maximapool-example.conf
+++ b/maximapool-example.conf
@@ -22,7 +22,7 @@ file.handling = true
 ##  %WORK-DIR-NE% use this if you do not want \-chars escaped
 ##  %OUTPUT-DIR% the directory that will be transferred to the client side
 ##  %OUTPUT-DIR-NE% use this if you do not want \-chars escaped
-maxima.path.command = TMP_IMG_DIR: "%WORK-DIR%/"; IMG_DIR: "%OUTPUT-DIR%/"; URL_BASE: "%PLOT-URL-BASE%";
+maxima.path.command = TMP_IMAGE_DIR: "%WORK-DIR%/"; IMAGE_DIR: "%OUTPUT-DIR%/"; URL_BASE: "%PLOT-URL-BASE%";
 
 
 ### Pool related parameters, times in milliseconds


### PR DESCRIPTION
It seems that the default configuration file contains an error: In the "maxima.path.command" parameter, the tokens IMG_DIR and TMP_IMG_DIR should read IMAGE_DIR and TMP_IMAGE_DIR respectively. This bug causes file handling (for plots) to break.
