### PR TITLE
Added case for change function that $addafter is not found.

### DIFF
--- a/doc/install.sh
+++ b/doc/install.sh
@@ -39,7 +39,11 @@ function change {
 		if [ $addafter = "$" ]; then
 			sed -i "$ a$toline" $file;
 		else
-			sed -i "/$addafter/a$toline" $file;
+			if grep -q "$addafter" $file;then
+				sed -i "/$addafter/a$toline" $file;
+			else
+				sed -i "$ a$toline" $file;
+			fi
 		fi
 	fi
 }


### PR DESCRIPTION
Sorry I realized that when the addafter line is not found then we should add line at the end of script.
I just added this.
