### PR TITLE
Close ReaderSucker in low level health check

### DIFF
--- a/src/fi/aalto/maximapool/MaximaServlet.java
+++ b/src/fi/aalto/maximapool/MaximaServlet.java
@@ -453,6 +453,7 @@ public class MaximaServlet extends HttpServlet {
 
 		healthcheckSendCommand("quit();\n", input, out);
 		input.close();
+		output.close();
 
 		HtmlUtils.writeParagraph(out, "Total time: " + (System.currentTimeMillis() - startTime) + " ms");
 		HtmlUtils.finishOutput(out);


### PR DESCRIPTION
to avoid thread leak due to low-level health check.

In MaximaServlet::doHealthcheckLowLevel(), close the ReaderSucker used. This seems to be safe because all data expected by the health check have been transferred when the instruction to close is reached. (i.e. there should be no read-after-free)

On https://github.com/uni-halle/maximapool-docker/issues/10 an issue was reported.
It turned out that each time a low-level health check was performed, a thread was created and never ended. That caused a monotonous increase in CPU usage until MaximaPool became unresponsive.

Maybe `foundEnd` in `utils/ReaderSucker.java` is never set to true?